### PR TITLE
JsonConverter implemented that serializes maybes as value or null

### DIFF
--- a/Sources/MayBee.Serialization.JsonNet/JsonNetExtensions.cs
+++ b/Sources/MayBee.Serialization.JsonNet/JsonNetExtensions.cs
@@ -4,18 +4,23 @@
 
     public static class JsonNetExtensions
     {
-        public static JsonSerializerSettings ConfigureMaybe(this JsonSerializerSettings settings)
+        public static JsonSerializerSettings ConfigureMaybe(this JsonSerializerSettings settings, SerializationFormat format = SerializationFormat.Nullable)
         {
-            settings.Converters.Add(new MaybeConverter());
-
+            settings.Converters.Add(GetConverter(format));
             return settings;
         }
 
-        public static JsonSerializer ConfigureMaybe(this JsonSerializer serializer)
+        public static JsonSerializer ConfigureMaybe(this JsonSerializer serializer, SerializationFormat format = SerializationFormat.Nullable)
         {
-            serializer.Converters.Add(new MaybeConverter());
-
+            serializer.Converters.Add(GetConverter(format));
             return serializer;
+        }
+
+        private static JsonConverter GetConverter(SerializationFormat format)
+        {
+            return format == SerializationFormat.Nullable
+                ? (JsonConverter)new MaybeAsNullableConverter()
+                : new MaybeAsArrayConverter();
         }
     }
 }

--- a/Sources/MayBee.Serialization.JsonNet/MayBee.Serialization.JsonNet.csproj
+++ b/Sources/MayBee.Serialization.JsonNet/MayBee.Serialization.JsonNet.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netstandard1.4</TargetFramework>
+        <TargetFramework>netstandard2.0</TargetFramework>
 
         <PackageId>MayBee.Serialization.JsonNet</PackageId>
         <PackageProjectUrl>https://github.com/thedmi/MayBee</PackageProjectUrl>

--- a/Sources/MayBee.Serialization.JsonNet/MaybeAsArrayConverter.cs
+++ b/Sources/MayBee.Serialization.JsonNet/MaybeAsArrayConverter.cs
@@ -1,0 +1,50 @@
+﻿namespace MayBee.Serialization.JsonNet
+{
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Reflection;
+
+    using MayBee;
+
+    using Newtonsoft.Json;
+
+    public class MaybeAsArrayConverter : JsonConverter
+    {
+        private static readonly Type _markerType = typeof(IMaybe);
+
+        private static readonly MethodInfo _emptyCreatorMethod = typeof(Maybe).GetTypeInfo().GetDeclaredMethod("Empty");
+        private static readonly MethodInfo _existingCreatorMethod = typeof(Maybe).GetTypeInfo().GetDeclaredMethod("Is");
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            var maybe = (IMaybe)value;
+
+            writer.WriteStartArray();
+            if (maybe.Exists)
+            {
+                var innerValue = maybe.GetType().GetTypeInfo().GetDeclaredProperty("It").GetValue(maybe);
+                serializer.Serialize(writer, innerValue);
+            }
+            writer.WriteEndArray();
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            var nestedType = objectType.GenericTypeArguments.Single();
+
+            var listType = typeof (IList<>).MakeGenericType(nestedType);
+            var valueList = (IList)serializer.Deserialize(reader, listType);
+
+            return valueList.Count == 0
+                ? _emptyCreatorMethod.MakeGenericMethod(nestedType).Invoke(null, new object[] { })
+                : _existingCreatorMethod.MakeGenericMethod(nestedType).Invoke(null, new[] { valueList[0] });
+        }
+
+        public override bool CanConvert(Type objectType)
+        {
+            return _markerType.GetTypeInfo().IsAssignableFrom(objectType.GetTypeInfo());
+        }
+    }
+}

--- a/Sources/MayBee.Serialization.JsonNet/SerializationFormat.cs
+++ b/Sources/MayBee.Serialization.JsonNet/SerializationFormat.cs
@@ -1,0 +1,15 @@
+namespace MayBee.Serialization.JsonNet
+{
+    public enum SerializationFormat
+    {
+        /// <summary>
+        /// Serialize maybe values as 'null' (empty) or the value (exists).
+        /// </summary>
+        Nullable, 
+        
+        /// <summary>
+        /// Serialize maybe values as array of length 0 (empty) or 1 (exists).
+        /// </summary>
+        Array
+    }
+}

--- a/Sources/MayBee/MayBee.csproj
+++ b/Sources/MayBee/MayBee.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netstandard1.4</TargetFramework>
+        <TargetFramework>netstandard2.0</TargetFramework>
 
         <PackageId>MayBee</PackageId>
         <Authors>Geopraevent AG</Authors>

--- a/Sources/MayBeeTest/MayBee.Serialization.JsonNet/MaybeAsArrayConverterTest.cs
+++ b/Sources/MayBeeTest/MayBee.Serialization.JsonNet/MaybeAsArrayConverterTest.cs
@@ -10,7 +10,7 @@
 
     using Xunit;
 
-    public class MaybeConverterTest
+    public class MaybeAsArrayConverterTest
     {
         private readonly JsonSerializerSettings _jsonSerializerSettings = new JsonSerializerSettings().ConfigureMaybe();
 

--- a/Sources/MayBeeTest/MayBee.Serialization.JsonNet/MaybeAsNullableConverterTest.cs
+++ b/Sources/MayBeeTest/MayBee.Serialization.JsonNet/MaybeAsNullableConverterTest.cs
@@ -1,0 +1,186 @@
+﻿namespace MayBeeTest.MayBee.Serialization.JsonNet
+{
+    using System.Collections.Generic;
+    using System.Diagnostics;
+
+    using global::MayBee;
+    using global::MayBee.Serialization.JsonNet;
+
+    using Newtonsoft.Json;
+
+    using Xunit;
+
+    public class MaybeAsNullableConverterTest
+    {
+        private readonly JsonSerializerSettings _jsonSerializerSettings;
+
+        public MaybeAsNullableConverterTest()
+        {
+            _jsonSerializerSettings = new JsonSerializerSettings();
+            _jsonSerializerSettings.Converters.Add(new MaybeAsNullableConverter());
+        }
+
+        [Fact]
+        public void Empty_maybe_roundtrips_successfully_to_json()
+        {
+            var testObj = new TestRefType { TheMaybe = Maybe.Empty<string>() };
+
+            var deserialized = PerformRoundtrip(testObj);
+
+            Assert.True(deserialized.TheMaybe.IsEmpty);
+        }
+
+        [Fact]
+        public void Existing_maybe_roundtrips_successfully_to_json()
+        {
+            var testObj = new TestRefType { TheMaybe = Maybe.Is("Hello maybe!") };
+
+            var deserialized = PerformRoundtrip(testObj);
+
+            Assert.True(deserialized.TheMaybe.Exists);
+            Assert.Equal("Hello maybe!", deserialized.TheMaybe.It);
+        }
+
+        [Fact]
+        public void Empty_value_maybe_roundtrips_successfully_to_json()
+        {
+            var testObj = new TestValueType { TheMaybe = Maybe.Empty<int>() };
+
+            var deserialized = PerformRoundtrip(testObj);
+
+            Assert.True(deserialized.TheMaybe.IsEmpty);
+        }
+
+        [Fact]
+        public void Existing_value_maybe_roundtrips_successfully_to_json()
+        {
+            var testObj = new TestValueType { TheMaybe = Maybe.Is(42) };
+
+            var deserialized = PerformRoundtrip(testObj);
+
+            Assert.True(deserialized.TheMaybe.Exists);
+            Assert.Equal(42, deserialized.TheMaybe.It);
+        }
+
+        [Fact]
+        public void Empty_boolean_maybes_roundtrip_sucessfully_to_json()
+        {
+            var testObj = new NestedType<bool> { TheMaybe = Maybe.Empty<bool>() };
+
+            var deserialized = PerformRoundtrip(testObj);
+
+            Assert.True(deserialized.TheMaybe.IsEmpty);
+        }
+
+        [Fact]
+        public void Existing_boolean_maybes_roundtrip_sucessfully_to_json()
+        {
+            var testObj = new NestedType<bool> { TheMaybe = Maybe.Is(false) };
+
+            var deserialized = PerformRoundtrip(testObj);
+
+            Assert.True(deserialized.TheMaybe.Exists);
+            Assert.False(deserialized.TheMaybe.It);
+        }
+
+        [Fact]
+        public void Empty_nested_maybe_roundtrips_successfully_to_json()
+        {
+            var testObj = new NestedType<InnerType> { TheMaybe = Maybe.Empty<InnerType>() };
+
+            var deserialized = PerformRoundtrip(testObj);
+
+            Assert.True(deserialized.TheMaybe.IsEmpty);
+        }
+
+        [Fact]
+        public void Existing_nested_maybe_roundtrips_successfully_to_json()
+        {
+            var testObj = new NestedType<InnerType> { TheMaybe = Maybe.Is(new InnerType { IntValue = 42, StringValue = "Heyo" }) };
+
+            var deserialized = PerformRoundtrip(testObj);
+
+            Assert.True(deserialized.TheMaybe.Exists);
+            Assert.Equal(42, deserialized.TheMaybe.It.IntValue);
+            Assert.Equal("Heyo", deserialized.TheMaybe.It.StringValue);
+        }
+
+        [Fact]
+        public void Empty_array_maybe_roundtrips_successfully_to_json()
+        {
+            var testObj = new NestedType<int[]> { TheMaybe = Maybe.Empty<int[]>() };
+
+            var deserialized = PerformRoundtrip(testObj);
+
+            Assert.True(deserialized.TheMaybe.IsEmpty);
+        }
+
+        [Fact]
+        public void Existing_array_maybe_roundtrips_successfully_to_json()
+        {
+            var testObj = new NestedType<int[]> { TheMaybe = Maybe.Is(new[] { 42, 43 }) };
+
+            var deserialized = PerformRoundtrip(testObj);
+
+            Assert.True(deserialized.TheMaybe.Exists);
+            Assert.Equal(2, deserialized.TheMaybe.It.Length);
+            Assert.Equal(42, deserialized.TheMaybe.It[0]);
+            Assert.Equal(43, deserialized.TheMaybe.It[1]);
+        }
+
+        private T PerformRoundtrip<T>(T testObj)
+        {
+            var json = JsonConvert.SerializeObject(testObj, _jsonSerializerSettings);
+
+            Debug.WriteLine(json);
+
+            return JsonConvert.DeserializeObject<T>(json, _jsonSerializerSettings);
+        }
+
+        [Fact]
+        public void Existing_nested_array_maybe_roundtrips_successfully_to_json()
+        {
+            var testObj = new ArrayType<TestValueType>
+                          {
+                              Values =
+                                  new[]
+                                  {
+                                      new TestValueType { TheMaybe = Maybe.Empty<int>() },
+                                      new TestValueType { TheMaybe = Maybe.Is(1) }
+                                  }
+                          };
+
+            var deserialized = PerformRoundtrip(testObj);
+
+            Assert.True(deserialized.Values.Count == 2);
+            Assert.True(deserialized.Values[0].TheMaybe.IsEmpty);
+            Assert.Equal(1, deserialized.Values[1].TheMaybe.It);
+        }
+
+        private class TestRefType
+        {
+            public IMaybe<string> TheMaybe { get; set; }
+        }
+
+        private class TestValueType
+        {
+            public IMaybe<int> TheMaybe { get; set; }
+        }
+
+        private class NestedType<T>
+        {
+            public IMaybe<T> TheMaybe { get; set; }
+        }
+
+        private class InnerType
+        {
+            public int IntValue { get; set; }
+            public string StringValue { get; set; }
+        }
+
+        private class ArrayType<T>
+        {
+            public IReadOnlyList<T> Values { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
The existing converter has been renamed to MaybeAsArrayConverter and is not the default anymore. This MR also switches to .NET Standard 2.0.