### PR TITLE
introduce Maybe#ItOr to extract values with a provided default

### DIFF
--- a/Sources/MayBee/IMaybe.cs
+++ b/Sources/MayBee/IMaybe.cs
@@ -25,6 +25,11 @@ namespace MayBee
         T ItOrDefault { get; }
 
         /// <summary>
+        /// Returns the value of the Maybe if it exists, or <paramref name="defaultValue"/> otherwise. 
+        /// </summary>
+        T ItOr(T defaultValue);
+
+        /// <summary>
         /// Returns <see cref="It"/> or throws <paramref name="exception"/> if it doesn't exist.
         /// </summary>
         [Obsolete]

--- a/Sources/MayBee/Maybe.cs
+++ b/Sources/MayBee/Maybe.cs
@@ -121,7 +121,12 @@ namespace MayBee
             }
         }
 
-        public T ItOrDefault { get { return _exists ? _value : default(T); } }
+        public T ItOr(T defaultValue)
+        {
+            return _exists ? _value : defaultValue;
+        }
+
+        public T ItOrDefault { get { return ItOr(default(T)); } }
 
         public T ItOrThrow(Exception exception)
         {

--- a/Sources/MayBee/MaybeExtensions.cs
+++ b/Sources/MayBee/MaybeExtensions.cs
@@ -44,7 +44,7 @@ namespace MayBee
 
         public static string ItOrEmpty(this IMaybe<string> maybe)
         {
-            return maybe.ItOrDefault ?? "";
+            return maybe.ItOr("");
         }
     }
 }

--- a/Sources/MayBeeTest/MayBee/MaybeTest.cs
+++ b/Sources/MayBeeTest/MayBee/MaybeTest.cs
@@ -116,6 +116,13 @@ namespace MayBeeTest.MayBee
         }
 
         [Fact]
+        public void CanProvideDefaultValue()
+        {
+            Assert.Equal("Hello", Maybe.Is("Hello").ItOr("Foo"));
+            Assert.Equal("Foo", Maybe.Empty<string>().ItOr("Foo"));
+        }
+
+        [Fact]
         public void StringMaybeItOrEmptyReturnsCorrectValue()
         {
             Assert.Equal("Hello", Maybe.Is("Hello").ItOrEmpty());


### PR DESCRIPTION
While ItOrEmpty provides a convenient way to deal with string types, there are case where it's useful
to be able to provide a given default fallback value for the empty case:

* working with Enumerable types, where the default value is the first listed but may not correspond
    to the appropriate default enumerable value for a given context
* providing specific default values based on context

For example:

```
var emailReplyAddress = user.supportAgent.Select(a => a.EmailAddress).ItOr("support@example.com");
```

Where `user.supportAgent` returns a maybe wrapping an object with an `EmailAddress` getter.

In addition, adding support for `ItOr` will streamline calling code, as there are many cases where we've got

```
maybe.Exists ? maybe.It : someOtherValue
```

which could then be refactored.