### PR TITLE
define Select in terms of SelectMany

### DIFF
--- a/Sources/MayBee/MaybeExtensions.cs
+++ b/Sources/MayBee/MaybeExtensions.cs
@@ -24,7 +24,7 @@ namespace MayBee
         /// </summary>
         public static Maybe<TResult> Select<T, TResult>(this IMaybe<T> maybe, Func<T, TResult> selector)
         {
-            return maybe.IsEmpty ? Maybe.Empty<TResult>() : Maybe.Is(selector(maybe.It));
+            return SelectMany(maybe, m => Maybe.Is(selector(m)));
         }
 
         /// <summary>


### PR DESCRIPTION
This refactoring makes it more obvious that they are closely related as in Category Theory.

(Obviously this is just a "nice to have" change that can be considered unnecessary, and certainly not requiring any release update if merged.)